### PR TITLE
fix: 홈페이지 QA 이슈 수정 및 법률 페이지 추가

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -60,10 +60,15 @@ const iconColors: Record<string, string> = {
               문서 보기
             </a>
             <a
-              href="/login"
-              class="flex items-center justify-center rounded-lg bg-surface border border-border px-4 py-2 text-sm font-bold text-white hover:bg-surface-elevated transition-colors"
+              href="https://github.com/curogom/choorai"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex items-center justify-center gap-2 rounded-lg bg-surface border border-border px-4 py-2 text-sm font-bold text-white hover:bg-surface-elevated transition-colors"
             >
-              로그인
+              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              GitHub
             </a>
           </div>
         </div>
@@ -103,6 +108,7 @@ const iconColors: Record<string, string> = {
               glow={true}
               fullWidth={true}
               icon="play"
+              href="/start/60min"
             >
               60분 완주 시작하기
             </Button>
@@ -112,6 +118,7 @@ const iconColors: Record<string, string> = {
               size="lg"
               fullWidth={true}
               icon="book"
+              href="/cycle/0-overview"
             >
               둘러보기
             </Button>
@@ -124,7 +131,6 @@ const iconColors: Record<string, string> = {
               client:load
               value={0}
               label="첫 배포 챌린지"
-              sublabel="현재 1,204명이 도전 중!"
             />
           </div>
         </div>
@@ -238,15 +244,15 @@ const iconColors: Record<string, string> = {
             <span class="text-white font-bold text-lg">Choorai</span>
           </div>
           <div class="flex items-center gap-8">
-            <a href="#" class="text-text-secondary hover:text-white transition-colors text-sm font-medium">블로그</a>
-            <a href="https://github.com" class="text-text-secondary hover:text-white transition-colors text-sm font-medium flex items-center gap-2">
+            <a href="https://www.keyflow.me/ko/@curogom" target="_blank" rel="noopener noreferrer" class="text-text-secondary hover:text-white transition-colors text-sm font-medium">블로그</a>
+            <a href="https://github.com/curogom/choorai" target="_blank" rel="noopener noreferrer" class="text-text-secondary hover:text-white transition-colors text-sm font-medium flex items-center gap-2">
               <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
               </svg>
               GitHub
             </a>
-            <a href="#" class="text-text-secondary hover:text-white transition-colors text-sm font-medium">이용약관</a>
-            <a href="#" class="text-text-secondary hover:text-white transition-colors text-sm font-medium">개인정보처리방침</a>
+            <a href="/terms" class="text-text-secondary hover:text-white transition-colors text-sm font-medium">이용약관</a>
+            <a href="/privacy" class="text-text-secondary hover:text-white transition-colors text-sm font-medium">개인정보처리방침</a>
           </div>
         </div>
         <div class="mt-8 pt-8 border-t border-border text-center md:text-left">

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -1,0 +1,134 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="개인정보처리방침">
+  <div class="min-h-screen bg-background">
+    <header class="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center h-16">
+          <a href="/" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
+            <div class="flex items-center justify-center w-8 h-8 rounded bg-primary/20 text-primary">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <span class="text-xl font-bold tracking-tight">Choorai</span>
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <h1 class="text-3xl font-bold text-white mb-8">개인정보처리방침</h1>
+
+      <div class="prose prose-invert max-w-none space-y-8">
+        <p class="text-text-secondary">최종 수정일: 2025년 1월 31일</p>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제1조 (개인정보의 수집)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            Choorai(이하 "서비스")는 이용자의 개인정보를 최소한으로 수집합니다. 현재 서비스는 회원가입 기능이 없으며, 다음과 같은 익명 정보만 자동으로 수집될 수 있습니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>방문 페이지 및 체류 시간 (웹 분석용)</li>
+            <li>브라우저 종류 및 운영체제</li>
+            <li>접속 국가/지역 (IP 주소 기반, 익명화 처리)</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제2조 (개인정보의 수집 목적)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            수집된 익명 정보는 다음 목적으로만 사용됩니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>서비스 이용 통계 분석</li>
+            <li>콘텐츠 개선 및 사용자 경험 향상</li>
+            <li>기술적 문제 해결</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제3조 (개인정보의 보관 및 파기)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            수집된 익명 분석 데이터는 서비스 개선 목적으로 보관되며, 개인을 식별할 수 있는 정보는 수집하지 않습니다. 향후 회원 기능이 추가될 경우, 해당 시점에 본 방침을 업데이트하겠습니다.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제4조 (개인정보의 제3자 제공)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            서비스는 이용자의 개인정보를 제3자에게 제공하지 않습니다. 단, 다음의 경우는 예외로 합니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>법령에 의해 요구되는 경우</li>
+            <li>수사 목적으로 법령에 정해진 절차에 따라 요청되는 경우</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제5조 (쿠키 사용)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            서비스는 사용자 경험 향상을 위해 쿠키를 사용할 수 있습니다. 쿠키는 다음 용도로 사용됩니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>학습 진행률 저장 (로컬 스토리지)</li>
+            <li>사용자 설정 유지</li>
+            <li>웹 분석 (익명화된 방문 통계)</li>
+          </ul>
+          <p class="text-text-secondary leading-relaxed">
+            브라우저 설정을 통해 쿠키 사용을 거부할 수 있으나, 일부 기능이 제한될 수 있습니다.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제6조 (이용자의 권리)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            이용자는 다음과 같은 권리를 행사할 수 있습니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>브라우저의 로컬 스토리지 및 쿠키 삭제</li>
+            <li>웹 분석 도구의 추적 거부 (Do Not Track 설정)</li>
+            <li>개인정보 처리에 관한 문의 및 이의 제기</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제7조 (개인정보의 안전성 확보)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            서비스는 다음과 같은 조치를 통해 정보 보안을 유지합니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>HTTPS를 통한 암호화 통신</li>
+            <li>최소한의 데이터만 수집</li>
+            <li>정기적인 보안 점검</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제8조 (방침의 변경)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            본 개인정보처리방침이 변경되는 경우, 변경 사항은 웹사이트를 통해 공지됩니다. 중요한 변경 사항은 최소 7일 전에 공지합니다.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제9조 (문의처)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            개인정보 처리에 관한 문의사항은 <a href="https://github.com/curogom/choorai/issues" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">GitHub Issues</a>를 통해 접수해 주시기 바랍니다.
+          </p>
+        </section>
+      </div>
+
+      <div class="mt-16 pt-8 border-t border-border">
+        <a href="/" class="text-primary hover:underline flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          홈으로 돌아가기
+        </a>
+      </div>
+    </main>
+  </div>
+</BaseLayout>

--- a/site/src/pages/terms.astro
+++ b/site/src/pages/terms.astro
@@ -1,0 +1,124 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="이용약관">
+  <div class="min-h-screen bg-background">
+    <header class="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center h-16">
+          <a href="/" class="flex items-center gap-3 hover:opacity-80 transition-opacity">
+            <div class="flex items-center justify-center w-8 h-8 rounded bg-primary/20 text-primary">
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <span class="text-xl font-bold tracking-tight">Choorai</span>
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <h1 class="text-3xl font-bold text-white mb-8">이용약관</h1>
+
+      <div class="prose prose-invert max-w-none space-y-8">
+        <p class="text-text-secondary">최종 수정일: 2025년 1월 31일</p>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제1조 (목적)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            본 약관은 Choorai(이하 "서비스")가 제공하는 웹 개발 학습 콘텐츠 및 관련 서비스의 이용 조건과 절차에 관한 사항을 규정함을 목적으로 합니다.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제2조 (서비스의 내용)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            서비스는 다음과 같은 콘텐츠를 무료로 제공합니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>웹 개발 입문자를 위한 학습 가이드</li>
+            <li>60분 배포 완주 튜토리얼</li>
+            <li>트러블슈팅 가이드</li>
+            <li>예시 프로젝트 및 코드</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제3조 (이용자의 의무)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            이용자는 다음 사항을 준수해야 합니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>서비스를 불법적인 목적으로 사용하지 않습니다</li>
+            <li>타인의 권리를 침해하지 않습니다</li>
+            <li>서비스의 정상적인 운영을 방해하지 않습니다</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제4조 (지적재산권)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            본 서비스의 콘텐츠는 <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ko" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">CC BY-NC-SA 4.0</a> 라이선스를 따릅니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li><strong class="text-white">저작자 표시</strong>: 원저작자를 표시해야 합니다</li>
+            <li><strong class="text-white">비영리</strong>: 상업적 목적으로 사용할 수 없습니다</li>
+            <li><strong class="text-white">동일조건변경허락</strong>: 변경 시 동일한 라이선스를 적용해야 합니다</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제5조 (면책조항)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            서비스는 무료로 제공되며, 다음 사항에 대해 보증하지 않습니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>콘텐츠의 정확성 및 완전성</li>
+            <li>서비스의 지속적인 제공</li>
+            <li>이용자가 서비스를 통해 얻은 결과</li>
+          </ul>
+          <p class="text-text-secondary leading-relaxed">
+            이용자는 본 서비스의 콘텐츠를 참고 자료로 활용하며, 실제 적용에 따른 책임은 이용자 본인에게 있습니다.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제6조 (서비스 변경 및 중단)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            서비스 제공자는 다음의 경우 서비스의 전부 또는 일부를 변경하거나 중단할 수 있습니다:
+          </p>
+          <ul class="list-disc list-inside text-text-secondary space-y-2 ml-4">
+            <li>기술적 필요에 의한 시스템 점검</li>
+            <li>콘텐츠 개선 및 업데이트</li>
+            <li>기타 운영상의 필요</li>
+          </ul>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제7조 (준거법 및 관할)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            본 약관의 해석 및 적용에 관하여는 대한민국 법률을 준거법으로 합니다.
+          </p>
+        </section>
+
+        <section class="space-y-4">
+          <h2 class="text-xl font-bold text-white">제8조 (문의)</h2>
+          <p class="text-text-secondary leading-relaxed">
+            본 약관에 관한 문의사항은 <a href="https://github.com/curogom/choorai/issues" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">GitHub Issues</a>를 통해 접수해 주시기 바랍니다.
+          </p>
+        </section>
+      </div>
+
+      <div class="mt-16 pt-8 border-t border-border">
+        <a href="/" class="text-primary hover:underline flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          홈으로 돌아가기
+        </a>
+      </div>
+    </main>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
- 로그인 버튼 → GitHub 링크로 변경
- 60분 챌린지 버튼에 href 추가 (/start/60min)
- 둘러보기 버튼에 href 추가 (/cycle/0-overview)
- "1,204명이 도전 중!" 허수 데이터 제거
- 푸터 링크 정비 (블로그, 이용약관, 개인정보처리방침)
- Button 컴포넌트에 href prop 지원 추가
- 이용약관 페이지 신규 생성 (/terms)
- 개인정보처리방침 페이지 신규 생성 (/privacy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개인정보 처리방침 및 이용약관 페이지 추가

* **개선사항**
  * 홈페이지 CTA 버튼에 네비게이션 링크 추가 (시작하기, 둘러보기)
  * 푸터 링크 개선 (GitHub 리포지토리 및 블로그 링크 추가, 정책 페이지 연결)
  * 버튼 컴포넌트 개선으로 링크 및 버튼 기능 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->