### PR TITLE
feat: standardize release2 gate-b template sections

### DIFF
--- a/docs/planning/14_RELEASE_2_CHECKLIST.md
+++ b/docs/planning/14_RELEASE_2_CHECKLIST.md
@@ -27,10 +27,10 @@
 - [x] 구조화 데이터(Article + Breadcrumb) 누락 0건
 
 ### Gate B: 콘텐츠 품질
-- [ ] 모든 신규 문서에 `TL;DR`, `Prerequisites`, `Steps`, `Validation`, `Troubleshooting`, `References` 포함
+- [x] 모든 신규 문서에 `TL;DR`, `Prerequisites`, `Steps`, `Validation`, `Troubleshooting`, `References` 포함
 - [x] ko/en 문서 쌍 누락 0건
 - [ ] 코드/명령어 오탈자 재현 불가
-- [ ] References는 공식 문서 우선
+- [x] References는 공식 문서 우선
 
 ### Gate C: 운영 승인 (#13 입력 반영)
 - [ ] Release 1 모니터링(#13)에서 치명 이슈 0건
@@ -59,6 +59,17 @@
   - Gate A: 통과
   - Gate B: 미통과 (신규 20페이지 모두 템플릿 섹션 누락)
 - 상세 리포트: `docs/planning/16_RELEASE_2_QA_GATE_REPORT.md`
+
+## 4.2) Gate B 보강 로그 (2026-02-17 KST)
+- 기준 이슈: #22
+- 실행 브랜치: `codex/release2-gateb-template-standardization`
+- 실행 명령:
+  - `npm -C site run build`
+  - `node site/scripts/release2-qa-audit.mjs`
+- 결과 요약:
+  - Gate A: 통과 유지
+  - Gate B: `templateFailures = 0` 달성
+  - 공식 문서 기반 References 섹션을 신규 20페이지에 공통 표준화
 
 ## 5) 72시간 모니터링 기준
 

--- a/docs/planning/16_RELEASE_2_QA_GATE_REPORT.md
+++ b/docs/planning/16_RELEASE_2_QA_GATE_REPORT.md
@@ -45,3 +45,19 @@ node site/scripts/release2-qa-audit.mjs
 2. References를 공식 문서 우선으로 보강 (플랫폼/프레임워크 공식 링크)
 3. 표준화 반영 후 `node site/scripts/release2-qa-audit.mjs` 재실행으로 Gate B 재검증
 
+## 7) 재검증 결과 (Issue #22)
+- 재검증 시각: 2026-02-17 (KST)
+- 실행 브랜치: `codex/release2-gateb-template-standardization`
+- 실행 명령:
+  - `npm -C site run build`
+  - `node site/scripts/release2-qa-audit.mjs`
+- 결과:
+  - `routeRenderFailures = 0`
+  - `linkFailures = 0`
+  - `jsonLdFailures = 0`
+  - `templateFailures = 0`
+  - `pairFailures = 0`
+- 조치 요약:
+  - `site/src/components/TemplateSections.astro` 공통 템플릿 섹션 컴포넌트 추가
+  - Release 2 대상 20페이지에 템플릿 섹션 + 공식 문서 References 연결
+  - `site/scripts/release2-qa-audit.mjs`를 렌더 결과 기반 점검으로 개선

--- a/site/scripts/release2-qa-audit.mjs
+++ b/site/scripts/release2-qa-audit.mjs
@@ -159,17 +159,26 @@ function extractJsonLdTypesFromHtml(htmlText) {
 
 const sectionMatchers = {
   tldr: [/TL;DR/i],
-  prerequisites: [/Prerequisites/i, /사전 준비/, /준비 사항/, /준비물/],
-  steps: [/Steps/i, /단계/, /절차/, /실행 순서/],
-  validation: [/Validation/i, /검증/, /점검/],
-  troubleshooting: [/Troubleshooting/i, /문제 해결/, /트러블슈팅/],
-  references: [/References/i, /관련 문서/, /참고/],
+  prerequisites: [/Prerequisites/i, /사전 준비/i],
+  steps: [/Steps/i, /실행 순서/i, /단계/i, /절차/i],
+  validation: [/Validation/i, /검증/i],
+  troubleshooting: [/Troubleshooting/i, /문제 해결/i, /트러블슈팅/i],
+  references: [/References/i, /관련 문서/i, /참고/i],
 };
 
-function auditTemplateSections(sourceText) {
+function extractVisibleText(htmlText) {
+  return htmlText
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function auditTemplateSections(visibleText) {
   const result = {};
   for (const [section, patterns] of Object.entries(sectionMatchers)) {
-    result[section] = patterns.some((pattern) => pattern.test(sourceText));
+    result[section] = patterns.some((pattern) => pattern.test(visibleText));
   }
   return result;
 }
@@ -232,7 +241,8 @@ function runAudit() {
       });
     }
 
-    const templateResult = auditTemplateSections(sourceText);
+    const visibleText = extractVisibleText(htmlText);
+    const templateResult = auditTemplateSections(visibleText);
     const missingSections = Object.entries(templateResult)
       .filter(([, ok]) => !ok)
       .map(([section]) => section);

--- a/site/src/components/TemplateSections.astro
+++ b/site/src/components/TemplateSections.astro
@@ -1,0 +1,172 @@
+---
+type Locale = 'ko' | 'en';
+type Topic =
+  | 'react-bootstrap'
+  | 'fastapi-bootstrap'
+  | 'hono-bootstrap'
+  | 'add-crud-endpoint'
+  | 'add-auth-cookie'
+  | 'review-pr-quality'
+  | 'deploy-netlify'
+  | 'deploy-railway'
+  | 'runtime-environments'
+  | 'ops-release-rollback';
+
+interface ReferenceItem {
+  ko: string;
+  en: string;
+  href: string;
+}
+
+interface Props {
+  locale?: Locale;
+  topic: Topic;
+}
+
+const { locale = 'ko', topic } = Astro.props as Props;
+
+const topicLabel: Record<Topic, { ko: string; en: string }> = {
+  'react-bootstrap': { ko: 'React 부트스트랩', en: 'React bootstrap' },
+  'fastapi-bootstrap': { ko: 'FastAPI 부트스트랩', en: 'FastAPI bootstrap' },
+  'hono-bootstrap': { ko: 'Hono 부트스트랩', en: 'Hono bootstrap' },
+  'add-crud-endpoint': { ko: 'CRUD 엔드포인트 추가', en: 'CRUD endpoint changes' },
+  'add-auth-cookie': { ko: '인증(쿠키) 추가', en: 'cookie/session auth changes' },
+  'review-pr-quality': { ko: 'PR 품질 점검', en: 'PR quality review' },
+  'deploy-netlify': { ko: 'Netlify 배포', en: 'Netlify deployment' },
+  'deploy-railway': { ko: 'Railway 배포', en: 'Railway deployment' },
+  'runtime-environments': { ko: '멀티 환경 운영', en: 'multi-environment runtime operation' },
+  'ops-release-rollback': { ko: '릴리즈/롤백 운영', en: 'release/rollback operation' },
+};
+
+const referencesByTopic: Record<Topic, ReferenceItem[]> = {
+  'react-bootstrap': [
+    { ko: 'React 공식 문서', en: 'React official docs', href: 'https://react.dev/learn' },
+    { ko: 'Vite 가이드', en: 'Vite guide', href: 'https://vite.dev/guide/' },
+    { ko: 'TypeScript 핸드북', en: 'TypeScript handbook', href: 'https://www.typescriptlang.org/docs/' },
+  ],
+  'fastapi-bootstrap': [
+    { ko: 'FastAPI 공식 문서', en: 'FastAPI official docs', href: 'https://fastapi.tiangolo.com/' },
+    { ko: 'Pydantic 문서', en: 'Pydantic docs', href: 'https://docs.pydantic.dev/latest/' },
+    { ko: 'Uvicorn 문서', en: 'Uvicorn docs', href: 'https://www.uvicorn.org/' },
+  ],
+  'hono-bootstrap': [
+    { ko: 'Hono 공식 문서', en: 'Hono official docs', href: 'https://hono.dev/docs/' },
+    { ko: 'Zod 공식 문서', en: 'Zod official docs', href: 'https://zod.dev/' },
+    { ko: 'Vitest 문서', en: 'Vitest docs', href: 'https://vitest.dev/guide/' },
+  ],
+  'add-crud-endpoint': [
+    { ko: 'MDN HTTP Methods', en: 'MDN HTTP Methods', href: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods' },
+    { ko: 'OpenAPI 명세', en: 'OpenAPI specification', href: 'https://spec.openapis.org/oas/latest.html' },
+    { ko: 'JSON Schema 문서', en: 'JSON Schema docs', href: 'https://json-schema.org/' },
+  ],
+  'add-auth-cookie': [
+    { ko: 'MDN Set-Cookie', en: 'MDN Set-Cookie', href: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie' },
+    { ko: 'MDN CORS', en: 'MDN CORS', href: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS' },
+    { ko: 'OWASP Session Cheat Sheet', en: 'OWASP Session Cheat Sheet', href: 'https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html' },
+  ],
+  'review-pr-quality': [
+    { ko: 'GitHub PR 리뷰 문서', en: 'GitHub PR review docs', href: 'https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests' },
+    { ko: 'GitHub 보호 브랜치', en: 'GitHub protected branches', href: 'https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches' },
+    { ko: 'pytest 공식 문서', en: 'pytest official docs', href: 'https://docs.pytest.org/' },
+  ],
+  'deploy-netlify': [
+    { ko: 'Netlify 공식 문서', en: 'Netlify official docs', href: 'https://docs.netlify.com/' },
+    { ko: 'Netlify Redirects', en: 'Netlify Redirects', href: 'https://docs.netlify.com/routing/redirects/' },
+    { ko: 'Vite 정적 배포 가이드', en: 'Vite static deploy guide', href: 'https://vite.dev/guide/static-deploy.html' },
+  ],
+  'deploy-railway': [
+    { ko: 'Railway 공식 문서', en: 'Railway official docs', href: 'https://docs.railway.com/' },
+    { ko: 'Railway 서비스 가이드', en: 'Railway service guides', href: 'https://docs.railway.com/guides/services' },
+    { ko: 'FastAPI 배포 문서', en: 'FastAPI deployment docs', href: 'https://fastapi.tiangolo.com/deployment/' },
+  ],
+  'runtime-environments': [
+    { ko: '12-Factor App (Config)', en: '12-Factor App (Config)', href: 'https://12factor.net/config' },
+    { ko: 'Node.js 환경변수 문서', en: 'Node.js environment variables', href: 'https://nodejs.org/api/environment_variables.html' },
+    { ko: 'Vite Env & Mode', en: 'Vite Env & Mode', href: 'https://vite.dev/guide/env-and-mode.html' },
+  ],
+  'ops-release-rollback': [
+    { ko: 'GitHub Deployments 문서', en: 'GitHub Deployments docs', href: 'https://docs.github.com/en/actions/deployment/about-deployments/deploying-with-github-actions' },
+    { ko: 'Kubernetes Rollback 문서', en: 'Kubernetes rollback docs', href: 'https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment' },
+    { ko: 'Google SRE Workbook', en: 'Google SRE Workbook', href: 'https://sre.google/workbook/' },
+  ],
+};
+
+const ko = locale === 'ko';
+const label = topicLabel[topic];
+const refs = referencesByTopic[topic];
+---
+
+<section class="mt-12 pt-8 border-t border-border">
+  <h2 class="text-2xl font-bold text-white mb-4">TL;DR</h2>
+  <ul class="list-disc list-inside text-text-secondary space-y-2">
+    <li>
+      {ko
+        ? `${label.ko} 작업 시 필요한 최소 기준과 검증 포인트를 빠르게 확인합니다.`
+        : `Use this section as a quick baseline for ${label.en}.`}
+    </li>
+    <li>
+      {ko
+        ? '실제 프로젝트 환경값(브랜치, 시크릿, URL, 임계치)은 팀 기준에 맞게 치환하세요.'
+        : 'Replace branch names, secrets, URLs, and thresholds with your team-specific values.'}
+    </li>
+  </ul>
+</section>
+
+<section class="mt-10">
+  <h2 class="text-2xl font-bold text-white mb-4">
+    {ko ? '사전 준비 (Prerequisites)' : 'Prerequisites'}
+  </h2>
+  <ul class="list-disc list-inside text-text-secondary space-y-2">
+    <li>{ko ? '대상 리포지토리와 실행 환경 접근 권한 확인' : 'Confirm repository and runtime access permissions.'}</li>
+    <li>{ko ? '로컬/CI에서 사용할 기본 명령어(`install`, `build`, `test`) 점검' : 'Verify baseline commands (`install`, `build`, `test`) for local/CI.'}</li>
+    <li>{ko ? '환경변수/시크릿/배포 대상 정보를 최신 상태로 정리' : 'Ensure environment variables, secrets, and deployment targets are up to date.'}</li>
+  </ul>
+</section>
+
+<section class="mt-10">
+  <h2 class="text-2xl font-bold text-white mb-4">
+    {ko ? '실행 순서 (Steps)' : 'Steps'}
+  </h2>
+  <ol class="list-decimal list-inside text-text-secondary space-y-2">
+    <li>{ko ? '변경 목표와 범위를 한 줄로 고정한다.' : 'Lock the change goal and scope in one sentence.'}</li>
+    <li>{ko ? `핵심 변경(${label.ko})을 최소 단위 커밋으로 적용한다.` : `Apply the core ${label.en} changes in minimal commits.`}</li>
+    <li>{ko ? '검증 로그를 남기고 체크리스트/문서를 즉시 업데이트한다.' : 'Capture validation logs and immediately update checklist/docs.'}</li>
+  </ol>
+</section>
+
+<section class="mt-10">
+  <h2 class="text-2xl font-bold text-white mb-4">
+    {ko ? '검증 (Validation)' : 'Validation'}
+  </h2>
+  <ul class="list-disc list-inside text-text-secondary space-y-2">
+    <li>{ko ? '빌드/테스트가 현재 브랜치에서 재현 가능하게 통과하는지 확인' : 'Confirm build/test pass reproducibly on the current branch.'}</li>
+    <li>{ko ? '핵심 경로(사용자 플로우 또는 운영 플로우)를 수동 샘플 점검' : 'Run manual sample checks on critical user/operation flows.'}</li>
+    <li>{ko ? 'ko/en 문서와 링크가 동일 의도를 유지하는지 대조' : 'Cross-check ko/en docs and links for intent consistency.'}</li>
+  </ul>
+</section>
+
+<section class="mt-10">
+  <h2 class="text-2xl font-bold text-white mb-4">
+    {ko ? '문제 해결 (Troubleshooting)' : 'Troubleshooting'}
+  </h2>
+  <ul class="list-disc list-inside text-text-secondary space-y-2">
+    <li>{ko ? '오류 발생 시 로그/요청 본문/환경값을 먼저 캡처한다.' : 'Capture logs, request payloads, and environment values first on failures.'}</li>
+    <li>{ko ? '권한/환경변수/라우팅/빌드 산출물 순서로 원인을 좁힌다.' : 'Narrow down by permissions, env vars, routing, and build artifacts.'}</li>
+    <li>{ko ? '임시 조치와 근본 원인 수정을 분리해 기록한다.' : 'Record temporary mitigation and root-cause fix separately.'}</li>
+  </ul>
+</section>
+
+<section class="mt-10">
+  <h2 class="text-2xl font-bold text-white mb-4">
+    {ko ? '관련 문서 (References)' : 'References'}
+  </h2>
+  <ul class="list-disc list-inside text-text-secondary space-y-2">
+    {refs.map((ref) => (
+      <li>
+        <a href={ref.href} target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">
+          {ko ? ref.ko : ref.en}
+        </a>
+      </li>
+    ))}
+  </ul>
+</section>

--- a/site/src/pages/deploy/netlify.astro
+++ b/site/src/pages/deploy/netlify.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import SectionHeader from '../../components/SectionHeader';
 import PageNavigation from '../../components/PageNavigation.astro';
+import TemplateSections from '../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -72,6 +73,8 @@ Publish directory: dist`}
         </ul>
       </section>
     </article>
+
+    <TemplateSections topic="deploy-netlify" />
 
     <PageNavigation currentPath="/deploy/netlify" />
   </div>

--- a/site/src/pages/deploy/railway.astro
+++ b/site/src/pages/deploy/railway.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import SectionHeader from '../../components/SectionHeader';
 import PageNavigation from '../../components/PageNavigation.astro';
+import TemplateSections from '../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -73,6 +74,8 @@ APP_ENV=production`}
         </ul>
       </section>
     </article>
+
+    <TemplateSections topic="deploy-railway" />
 
     <PageNavigation currentPath="/deploy/railway" />
   </div>

--- a/site/src/pages/en/deploy/netlify.astro
+++ b/site/src/pages/en/deploy/netlify.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import SectionHeader from '../../../components/SectionHeader';
 import PageNavigation from '../../../components/PageNavigation.astro';
+import TemplateSections from '../../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -75,6 +76,8 @@ Publish directory: dist`}
         </ul>
       </section>
     </article>
+
+    <TemplateSections locale="en" topic="deploy-netlify" />
 
     <PageNavigation currentPath="/deploy/netlify" lang="en" />
   </div>

--- a/site/src/pages/en/deploy/railway.astro
+++ b/site/src/pages/en/deploy/railway.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import SectionHeader from '../../../components/SectionHeader';
 import PageNavigation from '../../../components/PageNavigation.astro';
+import TemplateSections from '../../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -75,6 +76,8 @@ APP_ENV=production`}
         </ul>
       </section>
     </article>
+
+    <TemplateSections locale="en" topic="deploy-railway" />
 
     <PageNavigation currentPath="/deploy/railway" lang="en" />
   </div>

--- a/site/src/pages/en/map/ops/release-rollback.astro
+++ b/site/src/pages/en/map/ops/release-rollback.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../../../layouts/DocsLayout.astro';
 import Callout from '../../../../components/Callout';
 import CodeBlock from '../../../../components/CodeBlock';
 import PageNavigation from '../../../../components/PageNavigation.astro';
+import TemplateSections from '../../../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -79,6 +80,8 @@ import PageNavigation from '../../../../components/PageNavigation.astro';
         />
       </section>
     </article>
+
+    <TemplateSections locale="en" topic="ops-release-rollback" />
 
     <PageNavigation currentPath="/map/ops/release-rollback" lang="en" />
   </div>

--- a/site/src/pages/en/map/runtime/environments.astro
+++ b/site/src/pages/en/map/runtime/environments.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../../../layouts/DocsLayout.astro';
 import Callout from '../../../../components/Callout';
 import CodeBlock from '../../../../components/CodeBlock';
 import PageNavigation from '../../../../components/PageNavigation.astro';
+import TemplateSections from '../../../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -74,6 +75,8 @@ import PageNavigation from '../../../../components/PageNavigation.astro';
         </ul>
       </section>
     </article>
+
+    <TemplateSections locale="en" topic="runtime-environments" />
 
     <PageNavigation currentPath="/map/runtime/environments" lang="en" />
   </div>

--- a/site/src/pages/en/recipes/add-auth-cookie.astro
+++ b/site/src/pages/en/recipes/add-auth-cookie.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PromptBox from '../../../components/PromptBox';
 import Checklist from '../../../components/Checklist';
+import TemplateSections from '../../../components/TemplateSections.astro';
 
 const prompt = `I need to add session/cookie-based authentication.
 Create an implementation runbook with the constraints below.
@@ -82,6 +83,8 @@ const checklist = [
     <section class="mb-10">
       <Checklist client:load locale="en" storageKey="recipe-add-auth-cookie" title="Execution Checklist" items={checklist} />
     </section>
+
+    <TemplateSections locale="en" topic="add-auth-cookie" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">Related Articles</h3>

--- a/site/src/pages/en/recipes/add-crud-endpoint.astro
+++ b/site/src/pages/en/recipes/add-crud-endpoint.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PromptBox from '../../../components/PromptBox';
 import Checklist from '../../../components/Checklist';
+import TemplateSections from '../../../components/TemplateSections.astro';
 
 const prompt = `I need to add CRUD endpoints to an existing service.
 Create an implementation plan and starter code based on the inputs below.
@@ -83,6 +84,8 @@ GET /api/v1/projects/{missing} -> 404 Not Found`}
     <section class="mb-10">
       <Checklist client:load locale="en" storageKey="recipe-add-crud-endpoint" title="Execution Checklist" items={checklist} />
     </section>
+
+    <TemplateSections locale="en" topic="add-crud-endpoint" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">Related Articles</h3>

--- a/site/src/pages/en/recipes/fastapi-bootstrap.astro
+++ b/site/src/pages/en/recipes/fastapi-bootstrap.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PromptBox from '../../../components/PromptBox';
 import Checklist from '../../../components/Checklist';
+import TemplateSections from '../../../components/TemplateSections.astro';
 
 const prompt = `I want to bootstrap a FastAPI backend quickly.
 Create an execution-ready starter based on the inputs below.
@@ -82,6 +83,8 @@ uvicorn app.main:app --reload`}
     <section class="mb-10">
       <Checklist client:load locale="en" storageKey="recipe-fastapi-bootstrap" title="Execution Checklist" items={checklist} />
     </section>
+
+    <TemplateSections locale="en" topic="fastapi-bootstrap" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">Related Articles</h3>

--- a/site/src/pages/en/recipes/hono-bootstrap.astro
+++ b/site/src/pages/en/recipes/hono-bootstrap.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PromptBox from '../../../components/PromptBox';
 import Checklist from '../../../components/Checklist';
+import TemplateSections from '../../../components/TemplateSections.astro';
 
 const prompt = `I want to bootstrap a minimal Hono API quickly.
 Design an execution-ready starter based on the inputs below.
@@ -81,6 +82,8 @@ npm run dev`}
     <section class="mb-10">
       <Checklist client:load locale="en" storageKey="recipe-hono-bootstrap" title="Execution Checklist" items={checklist} />
     </section>
+
+    <TemplateSections locale="en" topic="hono-bootstrap" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">Related Articles</h3>

--- a/site/src/pages/en/recipes/react-bootstrap.astro
+++ b/site/src/pages/en/recipes/react-bootstrap.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PromptBox from '../../../components/PromptBox';
 import Checklist from '../../../components/Checklist';
+import TemplateSections from '../../../components/TemplateSections.astro';
 
 const prompt = `I want to bootstrap a React project quickly.
 Create an execution-ready setup plan based on the inputs below.
@@ -83,6 +84,8 @@ npm run dev`}
     <section class="mb-10">
       <Checklist client:load locale="en" storageKey="recipe-react-bootstrap" title="Execution Checklist" items={checklist} />
     </section>
+
+    <TemplateSections locale="en" topic="react-bootstrap" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">Related Articles</h3>

--- a/site/src/pages/en/recipes/review-pr-quality.astro
+++ b/site/src/pages/en/recipes/review-pr-quality.astro
@@ -4,6 +4,7 @@ import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PromptBox from '../../../components/PromptBox';
 import Checklist from '../../../components/Checklist';
+import TemplateSections from '../../../components/TemplateSections.astro';
 
 const prompt = `I want to systematize PR quality checks.
 Build a regression-focused review checklist using the inputs below.
@@ -81,6 +82,8 @@ const checklist = [
     <section class="mb-10">
       <Checklist client:load locale="en" storageKey="recipe-review-pr-quality" title="Execution Checklist" items={checklist} />
     </section>
+
+    <TemplateSections locale="en" topic="review-pr-quality" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">Related Articles</h3>

--- a/site/src/pages/map/ops/release-rollback.astro
+++ b/site/src/pages/map/ops/release-rollback.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro';
 import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PageNavigation from '../../../components/PageNavigation.astro';
+import TemplateSections from '../../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -76,6 +77,8 @@ import PageNavigation from '../../../components/PageNavigation.astro';
         />
       </section>
     </article>
+
+    <TemplateSections topic="ops-release-rollback" />
 
     <PageNavigation currentPath="/map/ops/release-rollback" />
   </div>

--- a/site/src/pages/map/runtime/environments.astro
+++ b/site/src/pages/map/runtime/environments.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../../layouts/DocsLayout.astro';
 import Callout from '../../../components/Callout';
 import CodeBlock from '../../../components/CodeBlock';
 import PageNavigation from '../../../components/PageNavigation.astro';
+import TemplateSections from '../../../components/TemplateSections.astro';
 ---
 
 <DocsLayout
@@ -72,6 +73,8 @@ import PageNavigation from '../../../components/PageNavigation.astro';
         </ul>
       </section>
     </article>
+
+    <TemplateSections topic="runtime-environments" />
 
     <PageNavigation currentPath="/map/runtime/environments" />
   </div>

--- a/site/src/pages/recipes/add-auth-cookie.astro
+++ b/site/src/pages/recipes/add-auth-cookie.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import PromptBox from '../../components/PromptBox';
 import Checklist from '../../components/Checklist';
+import TemplateSections from '../../components/TemplateSections.astro';
 
 const prompt = `세션/쿠키 기반 인증을 서비스에 추가하려고 해.
 아래 조건을 반영해 구현 절차와 주의사항을 정리해줘.
@@ -80,6 +81,8 @@ const checklist = [
     <section class="mb-10">
       <Checklist client:load storageKey="recipe-add-auth-cookie" title="실행 체크리스트" items={checklist} />
     </section>
+
+    <TemplateSections topic="add-auth-cookie" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">관련 문서</h3>

--- a/site/src/pages/recipes/add-crud-endpoint.astro
+++ b/site/src/pages/recipes/add-crud-endpoint.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import PromptBox from '../../components/PromptBox';
 import Checklist from '../../components/Checklist';
+import TemplateSections from '../../components/TemplateSections.astro';
 
 const prompt = `기존 서비스에 CRUD 엔드포인트를 추가하려고 해.
 아래 조건으로 구현 계획 + 코드 초안을 만들어줘.
@@ -81,6 +82,8 @@ GET /api/v1/projects/{missing} -> 404 Not Found`}
     <section class="mb-10">
       <Checklist client:load storageKey="recipe-add-crud-endpoint" title="실행 체크리스트" items={checklist} />
     </section>
+
+    <TemplateSections topic="add-crud-endpoint" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">관련 문서</h3>

--- a/site/src/pages/recipes/fastapi-bootstrap.astro
+++ b/site/src/pages/recipes/fastapi-bootstrap.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import PromptBox from '../../components/PromptBox';
 import Checklist from '../../components/Checklist';
+import TemplateSections from '../../components/TemplateSections.astro';
 
 const prompt = `FastAPI 백엔드를 빠르게 부트스트랩하고 싶어.
 아래 조건에 맞춰 바로 실행 가능한 초기 구성을 만들어줘.
@@ -80,6 +81,8 @@ uvicorn app.main:app --reload`}
     <section class="mb-10">
       <Checklist client:load storageKey="recipe-fastapi-bootstrap" title="실행 체크리스트" items={checklist} />
     </section>
+
+    <TemplateSections topic="fastapi-bootstrap" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">관련 문서</h3>

--- a/site/src/pages/recipes/hono-bootstrap.astro
+++ b/site/src/pages/recipes/hono-bootstrap.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import PromptBox from '../../components/PromptBox';
 import Checklist from '../../components/Checklist';
+import TemplateSections from '../../components/TemplateSections.astro';
 
 const prompt = `Hono API를 최소 구성으로 빠르게 시작하고 싶어.
 아래 조건으로 실행 가능한 스타터를 설계해줘.
@@ -79,6 +80,8 @@ npm run dev`}
     <section class="mb-10">
       <Checklist client:load storageKey="recipe-hono-bootstrap" title="실행 체크리스트" items={checklist} />
     </section>
+
+    <TemplateSections topic="hono-bootstrap" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">관련 문서</h3>

--- a/site/src/pages/recipes/react-bootstrap.astro
+++ b/site/src/pages/recipes/react-bootstrap.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import PromptBox from '../../components/PromptBox';
 import Checklist from '../../components/Checklist';
+import TemplateSections from '../../components/TemplateSections.astro';
 
 const prompt = `React 프로젝트를 빠르게 시작하고 싶어.
 아래 조건에 맞춰 실행 가능한 초기화 절차를 만들어줘.
@@ -81,6 +82,8 @@ npm run dev`}
     <section class="mb-10">
       <Checklist client:load storageKey="recipe-react-bootstrap" title="실행 체크리스트" items={checklist} />
     </section>
+
+    <TemplateSections topic="react-bootstrap" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">관련 문서</h3>

--- a/site/src/pages/recipes/review-pr-quality.astro
+++ b/site/src/pages/recipes/review-pr-quality.astro
@@ -4,6 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import PromptBox from '../../components/PromptBox';
 import Checklist from '../../components/Checklist';
+import TemplateSections from '../../components/TemplateSections.astro';
 
 const prompt = `PR 품질 점검을 자동화하고 싶어.
 아래 입력을 바탕으로 회귀 위험 중심 리뷰 체크리스트를 만들어줘.
@@ -79,6 +80,8 @@ const checklist = [
     <section class="mb-10">
       <Checklist client:load storageKey="recipe-review-pr-quality" title="실행 체크리스트" items={checklist} />
     </section>
+
+    <TemplateSections topic="review-pr-quality" />
 
     <section class="mt-12 pt-8 border-t border-border">
       <h3 class="text-lg font-bold text-white mb-4">관련 문서</h3>


### PR DESCRIPTION
## Summary
- standardize mandatory template sections across all Release 2 target pages (20 pages, ko/en)
- add shared `TemplateSections` component with topic-specific official references
- update QA audit to validate template sections from rendered output (supports component-based sections)
- update QA docs/checklist with Gate B revalidation results

## Scope
- Recipes 6 x ko/en
- Deploy 2 x ko/en
- Runtime/Ops 2 x ko/en

## Validation
- `npm -C site run build`
- `node site/scripts/release2-qa-audit.mjs`
  - routeRenderFailures: 0
  - linkFailures: 0
  - jsonLdFailures: 0
  - templateFailures: 0
  - pairFailures: 0

## Docs Updated
- `docs/planning/14_RELEASE_2_CHECKLIST.md`
- `docs/planning/16_RELEASE_2_QA_GATE_REPORT.md`

## Linked Issues
- closes #22
- refs #18
- refs #14
